### PR TITLE
Changed to remove scrollListener when unbind

### DIFF
--- a/library/src/main/java/ru/alexbykov/nopaginate/paginate/NoPaginate.java
+++ b/library/src/main/java/ru/alexbykov/nopaginate/paginate/NoPaginate.java
@@ -5,7 +5,6 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 
 import ru.alexbykov.nopaginate.callback.OnAdapterChangeListener;
-import ru.alexbykov.nopaginate.callback.OnLoadMore;
 import ru.alexbykov.nopaginate.callback.OnLoadMoreListener;
 import ru.alexbykov.nopaginate.callback.OnRepeatListener;
 import ru.alexbykov.nopaginate.item.DefaultGridLayoutItem;
@@ -72,13 +71,15 @@ public class NoPaginate implements OnAdapterChangeListener, OnRepeatListener {
 
 
     private void setupScrollListener() {
-        recyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
-            @Override
-            public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
-                checkScroll();
-            }
-        });
+        recyclerView.addOnScrollListener(scrollListener);
     }
+
+    private RecyclerView.OnScrollListener scrollListener = new RecyclerView.OnScrollListener() {
+        @Override
+        public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+            checkScroll();
+        }
+    };
 
     private void checkAdapterState() {
         if (isCanLoadMore()) {
@@ -172,10 +173,13 @@ public class NoPaginate implements OnAdapterChangeListener, OnRepeatListener {
             wrapperAdapter.unbind();
             userAdapter.unregisterAdapterDataObserver(wrapperAdapterObserver);
             recyclerView.setAdapter(userAdapter);
+            recyclerView.removeOnScrollListener(scrollListener);
 
         } else if (recyclerView.getLayoutManager() instanceof GridLayoutManager && wrapperSpanSizeLookup != null) {
             GridLayoutManager.SpanSizeLookup spanSizeLookup = wrapperSpanSizeLookup.getWrappedSpanSizeLookup();
             ((GridLayoutManager) recyclerView.getLayoutManager()).setSpanSizeLookup(spanSizeLookup);
+            recyclerView.removeOnScrollListener(scrollListener);
+
         }
     }
 


### PR DESCRIPTION
Thank you for making a good library.

If you create a paginate using the PaginateBuilder again after unbind, the onLoadMore event occurs twice.

The cause is that the scrollListener registered in the recyclerView is not cleared.

I used removeOnScrollListener because .clear () on the scrollListener also clears the user's registered scrollListener.

This issue also occurs in the 'master branch' and can be addressed in the same way.